### PR TITLE
Assigned Picked Player's Damage

### DIFF
--- a/Assets/PlayerPicker/loadPlayer.cs
+++ b/Assets/PlayerPicker/loadPlayer.cs
@@ -11,10 +11,11 @@ public class loadPlayer : MonoBehaviour {
         Playerlist[num2].transform.localPosition = new Vector3(0.1f, -0.51f, 0);
         for(int i = 0; i < 8; i++)
         {
-            if(i != num2)
-            {
-                Destroy(Playerlist[i]);
-            }
+			if (i != num2) {
+				Destroy (Playerlist [i]);
+			} else {
+				FindObjectOfType<DamageDisplay> ().damages [0] = Playerlist [i].GetComponent<Damage> ();
+			}
         }
 	}
 	


### PR DESCRIPTION
When Default Level starts and all non-chosen players are destroyed, the one chosen player will have their Damage component provided to the DamageDisplay object, allowing their accumulated damage to be shown.